### PR TITLE
Deprecate learning_curve! 

### DIFF
--- a/src/learning_curves.jl
+++ b/src/learning_curves.jl
@@ -112,8 +112,11 @@ learning_curve(mach::Machine{<:Supervised}; kwargs...) =
     learning_curve(mach.model, mach.args...; kwargs...)
 
 # for backwards compatibility
-learning_curve!(mach::Machine{<:Supervised}; kwargs...) =
+function learning_curve!(mach::Machine{<:Supervised}; kwargs...)
+    Base.depwarn("`learning_curve!` is deprecated, use `learning_curve` instead. ",
+            Core.Typeof(learning_curve!).name.mt.name)
     learning_curve(mach; kwargs...)
+end
 
 function learning_curve(model::Supervised, args...;
                         resolution=30,

--- a/src/learning_curves.jl
+++ b/src/learning_curves.jl
@@ -7,7 +7,7 @@
                                  measure=default_measure(machine.model),
                                  rows=nothing,
                                  weights=nothing,
-                                 operation=predict,
+                                 operation=nothing,
                                  range=nothing,
                                  acceleration=default_resource(),
                                  acceleration_grid=CPU1(),
@@ -26,8 +26,8 @@ the (possibly nested) RNG field, and a vector `rngs` of RNG's, one for
 each curve. Alternatively, set `rngs` to the number of curves desired,
 in which case RNG's are automatically generated. The individual curve
 computations can be distributed across multiple processes using
-`acceleration=CPUProcesses()` or `acceleration=CPUThreads()`. See the second example below for a
-demonstration.
+`acceleration=CPUProcesses()` or `acceleration=CPUThreads()`. See the
+second example below for a demonstration.
 
 ```julia
 X, y = @load_boston;
@@ -73,27 +73,6 @@ a machine.
 - `resolution` - number of points generated from `range` (number model
   evaluations); default is `30`
 
-- `resampling` - resampling strategy; default is `Holdout(fraction_train=0.7)`
-
-- `repeats` - set to more than `1` for repeated (Monte Carlo) resampling
-
-- `measure` - performance measure (metric); automatically inferred
-  from model by default when possible
-
-- `rows` - row indices to which resampling should be restricted;
-  default is all rows
-
-- `weights` - sample weights used by `measure` where supported
-
-- `operation` - operation, such as `predict`, to be used in
-  evaluations. If `prediction_type(mach.model) == :probabilistic` but
-  `prediction_type(measure) == :deterministic` consider `,`predict_mode`,
-  `predict_mode` or `predict_median`; default is `predict`.
-
-- `range` - object constructed using `range(model, ...)` or
-  `range(type, ...)` representing one-dimensional hyper-parameter
-  range.
-
 - `acceleration` - parallelization option for passing to `evaluate!`;
   an instance of `CPU1`, `CPUProcesses` or `CPUThreads` from the
   `ComputationalResources.jl`; default is `default_resource()`
@@ -106,6 +85,8 @@ a machine.
 
 - `rng_name` - name of the model hyper-parameter representing a random
   number generator (see above); possibly nested
+
+Other key-word options are documented at [`TunedModel`](@ref).
 
 """
 learning_curve(mach::Machine{<:Supervised}; kwargs...) =
@@ -125,7 +106,7 @@ function learning_curve(model::Supervised, args...;
                         measures=nothing,
                         measure=measures,
                         rows=nothing,
-                        operation=predict,
+                        operation=nothing,
                         ranges::Union{Nothing,ParamRange}=nothing,
                         range::Union{Nothing,ParamRange},
                         repeats=1,

--- a/src/tuned_models.jl
+++ b/src/tuned_models.jl
@@ -79,7 +79,7 @@ hyper-parameters are to be mutated.
     tuned_model = TunedModel(; models=<models to be compared>,
                              resampling=Holdout(),
                              measure=nothing,
-                             n=length(models), 
+                             n=length(models),
                              operation=nothing,
                              other_options...)
 

--- a/test/learning_curves.jl
+++ b/test/learning_curves.jl
@@ -215,5 +215,7 @@ end
                                      measure=LPLoss(),
                                      verbosity=0)
 
+end
+
 end # module
 true

--- a/test/learning_curves.jl
+++ b/test/learning_curves.jl
@@ -206,6 +206,14 @@ end
 
 end
 
+@testset "deprecation of learning_curve!" begin
+    atom = KNNRegressor()
+    mach = machine(atom, X, y)
+    r = range(atom, :K, lower=1, upper=2)
+    @test_deprecated learning_curve!(mach;
+                                     range=r,
+                                     measure=LPLoss(),
+                                     verbosity=0)
 
 end # module
 true


### PR DESCRIPTION
Addresses #60. Also makes `operation=nothing` the default for learning curves; see #148 for the reasoning. 