### PR TITLE
Fix a learning curve bug for case JULIA_NUM_THREADS = 1

### DIFF
--- a/src/learning_curves.jl
+++ b/src/learning_curves.jl
@@ -299,8 +299,12 @@ end
 
     n_threads = Threads.nthreads()
     if n_threads == 1
-        return _tuning_results(rngs, CPU1(),
-                         tuned, rng_name, verbosity)
+        return _tuning_results(rngs,
+                               CPU1(),
+                               tuned,
+                               rows,
+                               rng_name,
+                               verbosity)
     end
 
     old_rng = recursive_getproperty(tuned.model.model, rng_name)


### PR DESCRIPTION
In this PR we:

- (**bug fix**) Fix error thrown by `learning curve` when `acceleration isa CPUThreads` but `JULIA_NUM_THREADS = 1`.

To reproduce, run tests after starting up Julia with env variable `JULIA_NUM_THREADS = 1`.

