### PR TITLE
Allow uninstantiated `model`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MLJTuning"
 uuid = "03970b2e-30c4-11ea-3135-d1576263f10f"
 authors = ["Anthony D. Blaom <anthony.blaom@gmail.com>"]
-version = "0.7.1"
+version = "0.7.2"
 
 [deps]
 ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"

--- a/src/tuned_models.jl
+++ b/src/tuned_models.jl
@@ -260,11 +260,11 @@ function TunedModel(args...; model=nothing,
 
     # user can specify model as argument instead of kwarg:
     length(args) < 2 || throw(ERR_TOO_MANY_ARGUMENTS)
-    if length(args) === 1
+    if length(args) == 1
         arg = first(args)
         model === nothing ||
             @warn warn_double_spec(arg, model)
-        model =arg
+        model = arg
     end
 
     # either `models` is specified and `tuning` is set to `Explicit`,
@@ -309,7 +309,17 @@ function TunedModel(args...; model=nothing,
         else
             throw(ERR_MODEL_TYPE)
         end
+    elseif model isa Type && model <: Model
+        # Model is an uninstantiated model.
+        M = model
+        try
+            model = model()
+        catch
+            msg = "Unable to instantiate model $model; pass an instantiated model."
+            error(MethodError(msg))
+        end
     else
+        # Model is probably an instantiated model.
         M = typeof(model)
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,11 +9,7 @@ using StableRNGs
 # Display Number of processes and if necessary number
 # of Threads
 @info "nworkers: $(nworkers())"
-@static if VERSION >= v"1.3.0-DEV.573"
-    @info "nthreads: $(Threads.nthreads())"
-else
-    @info "Running julia $(VERSION). Multithreading tests excluded. "
-end
+@info "nthreads: $(Threads.nthreads())"
 
 include("test_utilities.jl")
 

--- a/test/tuned_models.jl
+++ b/test/tuned_models.jl
@@ -17,10 +17,10 @@ N = 30
 x1 = rand(N);
 x2 = rand(N);
 x3 = rand(N);
-X = (x1=x1, x2=x2, x3=x3);
+X = (; x1, x2, x3);
 y = 2*x1 .+ 5*x2 .- 3*x3 .+ 0.4*rand(N);
 
-m(K) = KNNRegressor(K=K)
+m(K) = KNNRegressor(; K)
 r = [m(K) for K in 13:-1:2]
 
 # TODO: replace the above with the line below and post an issue on
@@ -66,6 +66,9 @@ r = [m(K) for K in 13:-1:2]
     tm = @test_logs TunedModel(model=first(r), range=r, measure=rms)
     @test tm.tuning isa RandomSearch
     @test input_scitype(tm) == Table(Continuous)
+
+    # Allow uninstantiated model.
+    @test TunedModel(; model=KNNRegressor, range=r).model isa KNNRegressor
 end
 
 results = [(evaluate(model, X, y,


### PR DESCRIPTION
I was trying to do some hyperparameter tuning via
```julia
tunedmodel = let
    model = LogisticClassifier
    tuning = Grid()
    range = [
        range(Float64, :lambda; lower=0.01, upper=1, scale=:log),
        range(Float64, :gamma; lower=0.01, upper=1, scale=:log)
    ]
    measure = auc
    TunedModel(; model, tuning, range, measure)
end
```
and got
```
ArgumentError: Only `Deterministic` and `Probabilistic` model types supported.
```
which is very confusing. I had no idea what was the problem here. Fun fact, I got mad at the person who came up with this unclear error message. Turns out it was me https://github.com/JuliaAI/MLJTuning.jl/pull/157 :rofl: 

Anyway, this PR allows passing model types so that the code above will "automatically" work. I considered throwing a more clear error, but accepting a model type makes more sense IMO since the tuning strategy will instantiate many models.

Two thoughts:

- Maybe the instantiate which I wrapped in a try-catch should take the first elements for the range for the first instantiation. Or isn't the instantiated model used anyway?
- The `TunedModel` should probably be refactored since it is getting more and more tough to reason about it. We can either do a breaking change and explicitly create `TunedModel`, `TunedModels` and other constructors so that we avoid logic like "if `explicit` is set and `models` is not set, then`. Or, we could first figure out what kind of thing the user would like to do and dispatch into the appropriate function at the start of the `TunedModels` constructor