### PR TITLE
Clean up tests and code to avoid private access of machine.report

### DIFF
--- a/src/learning_curves.jl
+++ b/src/learning_curves.jl
@@ -196,7 +196,7 @@ _tuning_results(rngs::Nothing,
 
 function _single_curve(tuned, rows, verbosity)
     fit!(tuned, rows=rows, verbosity=verbosity, force=true)
-    tuned.report.plotting
+    report(tuned).plotting
 end
 
 # CPU1:
@@ -222,7 +222,7 @@ function _tuning_results(rngs::AbstractVector,
     ret = mapreduce(_collate, rngs) do rng
               recursive_setproperty!(tuned.model.model, rng_name, rng)
               fit!(tuned, rows=rows, verbosity=verbosity-1, force=true)
-              r =tuned.report.plotting
+              r =report(tuned).plotting
               verbosity < 1 || begin
                       p.counter += 1
                       ProgressMeter.updateProgress!(p)
@@ -269,7 +269,7 @@ function _tuning_results(rngs::AbstractVector,
     ret_ = @distributed (_collate) for rng in rngs
             recursive_setproperty!(tuned.model.model, rng_name, rng)
             fit!(tuned, rows=rows, verbosity=verbosity-1, force=true)
-            r=tuned.report.plotting
+            r=report(tuned).plotting
             verbosity < 1 || put!(channel, true)
             r
         end
@@ -348,7 +348,7 @@ end
                     fit!(tmachs[i], rows=rows,
                          verbosity=verbosity-1, force=true)
                     verbosity < 1 || put!(ch, true)
-                    tmachs[i].report.plotting
+                    report(tmachs[i]).plotting
                 end
             end
         end

--- a/test/models/Constant.jl
+++ b/test/models/Constant.jl
@@ -131,7 +131,7 @@ end
 function MMI.fit(::ConstantClassifier, verbosity::Int, A, y, w=nothing)
     fitresult = Distributions.fit(MLJBase.UnivariateFinite, y, w)
     cache     = nothing
-    report    = NamedTuple
+    report    = NamedTuple()
     return fitresult, cache, report
 end
 
@@ -181,26 +181,22 @@ metadata_model(ConstantRegressor,
                input=MMI.Table,
                target=AbstractVector{MMI.Continuous},
                weights=false,
-               descr="Constant regressor (Probabilistic).",
                path="MLJModels.ConstantRegressor")
 
 metadata_model(DeterministicConstantRegressor,
                input=MMI.Table,
                target=AbstractVector{MMI.Continuous},
                weights=false,
-               descr="Constant regressor (Deterministic).",
                path="MLJModels.DeterministicConstantRegressor")
 
 metadata_model(ConstantClassifier,
                input=MMI.Table,
                target=AbstractVector{<:MMI.Finite},
                weights=true,
-               descr="Constant classifier (Probabilistic).",
                path="MLJModels.ConstantClassifier")
 
 metadata_model(DeterministicConstantClassifier,
                input=MMI.Table,
                target=AbstractVector{<:MMI.Finite},
                weights=false,
-               descr="Constant classifier (Deterministic).",
                path="MLJModels.DeterministicConstantClassifier")

--- a/test/models/DecisionTree.jl
+++ b/test/models/DecisionTree.jl
@@ -206,11 +206,9 @@ metadata_pkg.((DecisionTreeClassifier, DecisionTreeRegressor),
 metadata_model(DecisionTreeClassifier,
                input=MLJBase.Table(Continuous, Count, OrderedFactor),
                target=AbstractVector{<:MLJBase.Finite},
-               weights=false,
-               descr=DTC_DESCR)
+               weights=false,)
 
 metadata_model(DecisionTreeRegressor,
                input=MLJBase.Table(Continuous, Count, OrderedFactor),
                target=AbstractVector{MLJBase.Continuous},
-               weights=false,
-               descr=DTR_DESCR)
+               weights=false,)

--- a/test/models/MultivariateStats.jl
+++ b/test/models/MultivariateStats.jl
@@ -131,12 +131,12 @@ metadata_pkg.((RidgeRegressor, PCA),
 metadata_model(RidgeRegressor,
                input=MLJBase.Table(MLJBase.Continuous),
                target=AbstractVector{MLJBase.Continuous},
-               weights=false,
-               descr=RIDGE_DESCR)
+               weights=false,)
+
 
 metadata_model(PCA,
                input=MLJBase.Table(MLJBase.Continuous),
                target=MLJBase.Table(MLJBase.Continuous),
-               weights=false,
-               descr=PCA_DESCR)
+               weights=false,)
+
 

--- a/test/models/NearestNeighbors.jl
+++ b/test/models/NearestNeighbors.jl
@@ -157,14 +157,12 @@ metadata_model(KNNRegressor,
     input=MLJBase.Table(MLJBase.Continuous),
     target=AbstractVector{MLJBase.Continuous},
     weights=true,
-    descr=KNNRegressorDescription
     )
 
 metadata_model(KNNClassifier,
     input=MLJBase.Table(MLJBase.Continuous),
     target=AbstractVector{<:MLJBase.Finite},
     weights=true,
-    descr=KNNClassifierDescription
     )
 
 

--- a/test/models/Transformers.jl
+++ b/test/models/Transformers.jl
@@ -583,40 +583,34 @@ metadata_model(FeatureSelector,
                input=MLJBase.Table(MLJBase.Scientific),
                output=MLJBase.Table(MLJBase.Scientific),
                weights=false,
-               descr=FEATURE_SELECTOR_DESCR,
                path="MLJBase.FeatureSelector")
 
 metadata_model(UnivariateDiscretizer,
                input=AbstractVector{<:MLJBase.Continuous},
                output=AbstractVector{<:MLJBase.OrderedFactor},
                weights=false,
-               descr=UNIVARIATE_DISCR_DESCR,
                path="MLJBase.UnivariateDiscretizer")
 
 metadata_model(UnivariateStandardizer,
                input=AbstractVector{<:MLJBase.Infinite},
                output=AbstractVector{MLJBase.Continuous},
                weights=false,
-               descr=UNIVARIATE_STD_DESCR,
                path="MLJBase.UnivariateStandardizer")
 
 metadata_model(Standardizer,
                input=MLJBase.Table(MLJBase.Scientific),
                output=MLJBase.Table(MLJBase.Scientific),
                weights=false,
-               descr=STANDARDIZER_DESCR,
                path="MLJBase.Standardizer")
 
 metadata_model(UnivariateBoxCoxTransformer,
                input=AbstractVector{MLJBase.Continuous},
                output=AbstractVector{MLJBase.Continuous},
                weights=false,
-               descr=UNIVARIATE_BOX_COX_DESCR,
                path="MLJBase.UnivariateBoxCoxTransformer")
 
 metadata_model(OneHotEncoder,
                input=MLJBase.Table(MLJBase.Scientific),
                output=MLJBase.Table(MLJBase.Scientific),
                weights=false,
-               descr=ONE_HOT_DESCR,
                path="MLJBase.OneHotEncoder")

--- a/test/strategies/grid.jl
+++ b/test/strategies/grid.jl
@@ -178,7 +178,7 @@ end
     # test weights:
     tuned_model.weights = rand(length(y))
     fit!(tuned, verbosity=0)
-    @test e_training != tuned.report.best_history_entry.measurement[1]
+    @test e_training != report(tuned).best_history_entry.measurement[1]
 
     # test plotting part of report:
     @test r.plotting.parameter_names ==

--- a/test/tuned_models.jl
+++ b/test/tuned_models.jl
@@ -233,7 +233,6 @@ end
 
     m(b) = ConstantClassifier(testing=true, bogus=b)
     r = [m(b) for b in 1:5]
-
     tuned_model = TunedModel(
         models=r,
         resampling=Holdout(fraction_train=0.8),


### PR DESCRIPTION
~~No new release required.~~

Changes to MLJBase (in a planned future breaking release) will replace `mach.report` with a dictionary, while preserving the current behaviour of `report(mach)`. For MLJTuning to work with those changes, this PR is needed. 