### PR TITLE
Fix how measures are displayed on plot axes

### DIFF
--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,6 +1,6 @@
 @recipe function f(mach::MLJBase.Machine{<:EitherTunedModel})
     rep = report(mach)
-    measurement = string(typeof(rep.best_history_entry.measure[1]))
+    measurement = repr(rep.best_history_entry.measure[1])
     r = rep.plotting
     z = r.measurements
     X = r.parameter_values


### PR DESCRIPTION
<img width="754" alt="Screen Shot 2024-01-19 at 9 28 37 AM" src="https://github.com/JuliaAI/MLJTuning.jl/assets/30517088/5195a32d-c92b-44b7-8ad8-32b3a0208b62">

instead of 

<img width="751" alt="Screen Shot 2024-01-19 at 9 29 42 AM" src="https://github.com/JuliaAI/MLJTuning.jl/assets/30517088/784cde60-e4e3-473f-97b8-1d47139e75f0">
