### PR TITLE
Add `history_additions` to resolve #202 at least for grid searches

### DIFF
--- a/src/tuned_models.jl
+++ b/src/tuned_models.jl
@@ -439,7 +439,9 @@ function event!(metamodel,
               measure     = E.measure,
               measurement = E.measurement,
               per_fold    = E.per_fold,
-              metadata    = metadata)
+              metadata    = metadata,
+              evaluation  = E,
+    )
     entry = merge(entry0, extras(tuning, history, state, E))
     if verbosity > 2
         println("hyperparameters: $(params(model))")


### PR DESCRIPTION
This adds the `history_additions` option to `TunedModel` which allows to specify a function `f` which is then called on each set of folds during tuning as `f(model, fitted_params_per_fold)` where
- `model` is the configuration the tuner is currently looking at and
- `fitted_params_per_fold` is the vector of `fitted_params(mach)` for each `mach` trained during resampling (e.g. this has 5 entries if 5-fold CV is used)—see [here](https://github.com/JuliaAI/MLJBase.jl/blob/master/src/resampling.jl#L518).

This closes #202 to some extent since when using searches that do not adjust their search space based on their trajectory (e.g. `Grid` and `LatinHypercube`), this allows to optimize with respect to functions that are not exclusively predictive performance–based. For example:

```Julia
using MLJTuning
using MLJ
DTRegressor = @load DecisionTreeRegressor pkg = DecisionTree verbosity = 0
using DecisionTree: DecisionTree

N = 800
X, y = rand(N, 5), rand(N)
X = MLJ.table(X)

model = DTRegressor()

space = [
    range(model, :max_depth; lower=1, upper=5),
    range(
        model,
        :min_samples_split;
        lower=ceil(0.001 * N),
        upper=ceil(0.05 * N),
    ),
]

function histadds(model, fitted_params_per_fold)
    return DecisionTree.depth.(getproperty.(fitted_params_per_fold, :raw_tree))
end

struct HistoryAdditionsSelection <: MLJTuning.SelectionHeuristic end

function MLJTuning.best(::HistoryAdditionsSelection, history)
    # Compute the mean of the depths stored in `history_additions`.
    scores = mean.(getproperty.(history, :history_additions))
    # Within this contrived example, the best hyperparametrization is the one
    # resulting in the least mean depth.
    index_best = argmin(scores)
    return history[index_best]
end

# Let's pirate some types. Julia, please forgive me.
function MLJTuning.supports_heuristic(
    ::LatinHypercube,
    ::HistoryAdditionsSelection,
)
    return true
end

modelt = TunedModel(;
    model=model,
    resampling=CV(; nfolds=3),
    tuning=LatinHypercube(; gens=30),
    range=space,
    measure=mae,
    n=10,
    history_additions=histadds,
    selection_heuristic=HistoryAdditionsSelection(),
)

macht = machine(modelt, X, y)
MLJ.fit!(macht; verbosity=1000)
display(getproperty.(report(macht).history, :history_additions))
```