### PR TITLE
Update codecov action to @v4; try to use org secret token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,4 @@ jobs:
         with:
           token: token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-          files: lcov.info
           verbose: true 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,9 @@ jobs:
         env:
           JULIA_NUM_THREADS: '2'
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
-          token: 080b3e97-0ae1-4282-b626-bcc1a93d158c
-          files: lcov.info
+          token: token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+          files: lcov.info
           verbose: true 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,6 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
-          token: token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true 


### PR DESCRIPTION
I've attempted to retrieve the codecov token for JuliaAI org and created a secret to store it at the org level. So hopefully this works...

Following the guidance at https://discourse.julialang.org/t/psa-new-version-of-codecov-action-requires-additional-setup/109857